### PR TITLE
Add embassy-traits dep with git revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ embassy = { version = "0.1", default-features = false, features = ["executor-agn
 embedded-hal = { version = "0.2", features = ["unproven"] }
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3.4", features = ['Document', 'Element', 'HtmlElement', 'Node', 'Window'] }
+
+[patch.crates-io]
+embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "a2e7c24e0055d13a61345dfce9fbe7fcf4e0d306" }


### PR DESCRIPTION
This commit attempts to fix the following compilation error by adding a
patch.crates-io key with a git revision that contains the `gpio` trait:
```console
error[E0432]: unresolved import `embassy::traits::gpio`
 --> src/components.rs:5:22
  |
5 | use embassy::traits::gpio::WaitForAnyEdge;
  |                      ^^^^ could not find `gpio` in `traits`

For more information about this error, try `rustc --explain E0432`.
```